### PR TITLE
Fix dependencies and generate .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,70 @@
+# Created by https://www.gitignore.io/api/gradle,eclipse,java
+
+### Gradle ###
+.gradle
+build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+
+### Eclipse ###
+*.pydevproject
+.metadata
+.gradle
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+
+# Eclipse Core
+.project
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# CDT-specific
+.cproject
+
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# TeXlipse plugin
+.texlipse
+
+
+### Java ###
+*.class
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,8 @@ repositories {
 }
 
 dependencies {
-    compile group: "org.dita-ot", name: "dost", version: "2.0"
+    compile group: "com.github.dita-ot", name: "dost", version: "2.1.0"
+    compile group: "commons-io", name: "commons-io", version: "2.4"
     compile group: "org.pegdown", name: "pegdown", version: "1.4.2"
     testCompile group: 'junit', name: 'junit', version: '4.11'
 }


### PR DESCRIPTION
Add *commons-io* as a dependency. Changed *dost* version to *2.1.0* according to the **Requirements** section of the *README.md* that says:

> DITA-OT 2.1 is required. Earlier versions of DITA-OT do not have the required extension points.

Also generate .gitignore using gitignore.io using the tags 'eclipse,java,gradle'.
