### PR TITLE
Disable family links for GitBook output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Gradle task artifacts & build results
+.gradle/
+build/

--- a/README.md
+++ b/README.md
@@ -19,18 +19,20 @@ required extension points.
 Build
 -----
 
-1.  Run Gradle distribution task
+1.  To build the DITA-OT Markdown plug-in for local testing, first install the DITA-OT distribution JAR file dependencies by running `gradle install` from your clone of the [DITA-OT repository](https://github.com/dita-ot/dita-ot).
+    The required dependencies are installed to a local Maven repository in your home directory under `.m2/repository/org/dita-ot/dost/`. 
+2.  Run the Gradle distribution task to generate the plug-in distribution package:
 
     ~~~~ {.sh}
     ./gradlew dist
     ~~~~
 
-Distribution ZIP file is generated under `build/distributions`.
+    The distribution ZIP file is generated under `build/distributions`.
 
 Install
 -------
 
-1.  Run plug-in installation command
+1.  Run the plug-in installation command:
 
     ~~~~ {.sh}
     dita -install https://github.com/jelovirt/dita-ot-markdown/releases/download/1.1.0/com.elovirta.dita.markdown_1.1.0.zip
@@ -43,6 +45,8 @@ to `CLASSPATH` with e.g. `-lib plugins/com.elovirta.dita.markdown`.
 Usage
 -----
 
+### Using Markdown files as input
+
 Markdown DITA topics can only be used by linking to them in map files.
 
 ~~~~ {.xml}
@@ -52,12 +56,20 @@ Markdown DITA topics can only be used by linking to them in map files.
 ~~~~
 
 The `format` attribute value must be set to `markdown` in order to
-recognize files as Markdown DITA; file extension is not used to
+recognize files as Markdown DITA; the file extension is not used to
 recognize format.
 
-To publish Markdown DITA files, use `markdown` transtype.
-
 See [Syntax reference](https://github.com/jelovirt/dita-ot-markdown/wiki/Syntax-reference) for XML and Markdown DITA correspondence.
+
+### Generating Markdown output
+
+The DITA-OT Markdown plug-in extends the DITA Open Toolkit with additional output formats _(transformation types)_ that can be used to publish DITA content as Markdown.
+
+* To publish Markdown DITA files, use the `markdown` transtype.
+
+* To generate [GitHub Flavored Markdown](https://help.github.com/categories/writing-on-github/) files, use the `markdown_github` transtype.
+
+* To publish GitHub Flavored Markdown and generate a  `SUMMARY.md` table of contents file for publication via [GitBook](https://www.gitbook.com), use the `markdown_gitbook` transtype.
 
 Donating
 --------

--- a/src/main/build_template.xml
+++ b/src/main/build_template.xml
@@ -38,6 +38,11 @@
         <isset property="args.markdown.toc" />
       </not>
     </condition>
+    <condition property="args.rellinks" value="nofamily">
+      <not>
+        <isset property="args.rellinks" />
+      </not>
+    </condition>
   </target>
     
   <target name="dita2markdown"


### PR DESCRIPTION
GitBook provides navigation affordances including keyboard shortcuts for ← previous/next → topics, and a visible ToC hierarchy, so parent, child, next, and previous links can be safely disabled when generating output via the `markdown_gitbook` transtype.

This PR also adds info on the new transtypes to the ReadMe and adds `.gitignore` entries for Gradle task artifacts & build results.

