### PR TITLE
Fixes/task specialize

### DIFF
--- a/src/main/resources/specialize.xsl
+++ b/src/main/resources/specialize.xsl
@@ -84,14 +84,30 @@
   <xsl:template match="body[$type = 'task']/ol/li | body[$type = 'task']/ul/li">
     <step class="- topic/li task/step ">
       <xsl:apply-templates select="@* except @class"/>
-      <xsl:for-each select="*[1]">
-        <cmd class="- topic/ph task/cmd ">
-          <xsl:apply-templates select="@* except @class | node()"/>
-        </cmd>
-      </xsl:for-each>
-      <info class="- topic/itemgroup task/info ">
-        <xsl:apply-templates select="*[position() gt 1]"/>
-      </info>
+      <xsl:choose>
+        <xsl:when test="node()[1][self::text()][normalize-space()!='']">
+          <cmd class="- topic/ph task/cmd ">
+            <xsl:copy-of select="node()[1]"/>
+          </cmd>
+          <xsl:if test="*">
+            <info class="- topic/itemgroup task/info ">
+              <xsl:apply-templates select="*"/>
+            </info>  
+          </xsl:if>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:for-each select="*[1]">
+            <cmd class="- topic/ph task/cmd ">
+              <xsl:apply-templates select="@* except @class | node()"/>
+            </cmd>
+          </xsl:for-each>
+          <xsl:if test="*[2]">
+            <info class="- topic/itemgroup task/info ">
+              <xsl:apply-templates select="*[position() gt 1]"/>
+            </info>    
+          </xsl:if>
+        </xsl:otherwise>
+      </xsl:choose>
     </step>
   </xsl:template>
 

--- a/src/test/java/com/elovirta/dita/markdown/MarkdownReaderTest.java
+++ b/src/test/java/com/elovirta/dita/markdown/MarkdownReaderTest.java
@@ -121,6 +121,11 @@ public class MarkdownReaderTest {
     }
 
     @Test
+    public void testTaskOneStep() throws Exception {
+        run("taskOneStep.md");
+    }
+
+    @Test
     public void testReference() throws Exception {
         run("reference.md");
     }

--- a/src/test/resources/taskOneStep.dita
+++ b/src/test/resources/taskOneStep.dita
@@ -1,0 +1,17 @@
+<task xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+  class="- topic/topic task/task " id="task">
+  <title class="- topic/title ">Task </title>
+  <taskbody class="- topic/body task/taskbody ">
+    <context class="- topic/section task/context ">
+      <p class="- topic/p ">Context</p>
+    </context>
+    <steps class="- topic/ol task/steps ">
+      <step class="- topic/li task/step ">
+        <cmd class="- topic/ph task/cmd ">Command</cmd>
+        <info class="- topic/itemgroup task/info ">
+          <p class="- topic/p ">Info.</p>
+        </info>
+      </step>
+    </steps>
+  </taskbody>
+</task>

--- a/src/test/resources/taskOneStep.md
+++ b/src/test/resources/taskOneStep.md
@@ -1,0 +1,7 @@
+# Task {.task}
+
+Context
+
+1.  Command
+
+    Info.


### PR DESCRIPTION
The sample from the [syntax reference](https://github.com/jelovirt/dita-ot-markdown/wiki/Syntax-reference) document that shows how a task structure looks like did not convert correctly, the command text was lost and the info migrated into command.
This adds a test case and provides a fix.
