### PR TITLE
Fix project name to match the GitHub project name.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
-rootProject.name = 'markdown'
+rootProject.name = 'dita-ot-markdown'
 


### PR DESCRIPTION
Trying to setup the project in my Eclipse environment, I got an error that the project name does not match the gradle project name, one is `dita-ot-markdown` and the other `markdown`.
If the gradle project name should match what we get by default when we clone the project then the change is provided by this pull request.