### PR TITLE
Remove prereq, context, result and postreq as sections

### DIFF
--- a/src/main/java/com/elovirta/dita/markdown/ToDitaSerializer.java
+++ b/src/main/java/com/elovirta/dita/markdown/ToDitaSerializer.java
@@ -70,10 +70,6 @@ public class ToDitaSerializer implements Visitor {
     static {
         sections.put(TOPIC_SECTION.localName, TOPIC_SECTION);
         sections.put(TOPIC_EXAMPLE.localName, TOPIC_EXAMPLE);
-        sections.put(TASK_PREREQ.localName, TASK_PREREQ);
-        sections.put(TASK_CONTEXT.localName, TASK_CONTEXT);
-        sections.put(TASK_RESULT.localName, TASK_RESULT);
-        sections.put(TASK_POSTREQ.localName, TASK_POSTREQ);
     }
 
     private final ContentHandler contentHandler;


### PR DESCRIPTION
These elements do not allow title, so if we treat them as sections we will create invalid DITA.