### PR TITLE
Generate format="markdown" on links to .md or .markdown files.

### DIFF
--- a/src/main/java/com/elovirta/dita/markdown/ToDitaSerializer.java
+++ b/src/main/java/com/elovirta/dita/markdown/ToDitaSerializer.java
@@ -911,6 +911,8 @@ public class ToDitaSerializer implements Visitor {
         switch (ext) {
             case ATTR_FORMAT_VALUE_DITA:
             case "xml":
+            	format = null;
+            	break;
                 // Markdown is converted to DITA
             case "md":
             case "markdown":

--- a/src/main/java/com/elovirta/dita/markdown/ToDitaSerializer.java
+++ b/src/main/java/com/elovirta/dita/markdown/ToDitaSerializer.java
@@ -914,7 +914,7 @@ public class ToDitaSerializer implements Visitor {
                 // Markdown is converted to DITA
             case "md":
             case "markdown":
-                format = null;
+                format = "markdown";
                 break;
             default:
                 format = !ext.isEmpty() ? ext : "html";

--- a/src/test/resources/link.dita
+++ b/src/test/resources/link.dita
@@ -4,7 +4,7 @@
   <title class="- topic/title ">Links</title>
   <body class="- topic/body ">
     <p class="- topic/p ">
-      <xref class="- topic/xref " href="concept.md">Markdown</xref>
+      <xref class="- topic/xref " href="concept.md" format="markdown">Markdown</xref>
     </p>
     <p class="- topic/p ">
       <xref class="- topic/xref " href="topic.dita">DITA</xref>

--- a/src/test/resources/test.dita
+++ b/src/test/resources/test.dita
@@ -118,7 +118,7 @@
     <body class="- topic/body ">
       <ul class="- topic/ul ">
         <li class="- topic/li ">
-          <xref class="- topic/xref " href="test.md">Markdown</xref>
+          <xref class="- topic/xref " href="test.md" format="markdown">Markdown</xref>
         </li>
         <li class="- topic/li ">
           <xref class="- topic/xref " href="test.dita">DITA</xref>
@@ -136,10 +136,10 @@
   <topic class="- topic/topic " id="keys">
     <title class="- topic/title ">Keys</title>
     <body class="- topic/body ">
-      <p class="- topic/p ">This is <xref class="- topic/xref " href="test.md">an example</xref> reference-style link.</p>
-      <p class="- topic/p ">This is <xref class="- topic/xref " href="test.md">key-a</xref> reference-style link.</p>
-      <p class="- topic/p ">This is <xref class="- topic/xref " href="test.md">Markdown</xref> reference-style link.</p>
-      <p class="- topic/p ">This is <xref class="- topic/xref " href="test.md">Markdown</xref> reference-style link.</p>
+      <p class="- topic/p ">This is <xref class="- topic/xref " href="test.md" format="markdown">an example</xref> reference-style link.</p>
+      <p class="- topic/p ">This is <xref class="- topic/xref " href="test.md" format="markdown">key-a</xref> reference-style link.</p>
+      <p class="- topic/p ">This is <xref class="- topic/xref " href="test.md" format="markdown">Markdown</xref> reference-style link.</p>
+      <p class="- topic/p ">This is <xref class="- topic/xref " href="test.md" format="markdown">Markdown</xref> reference-style link.</p>
       <p class="- topic/p ">This is <xref class="- topic/xref " keyref="key-missing">an example</xref> reference-style link.</p>
       <p class="- topic/p ">This is <xref class="- topic/xref " keyref="key-missing"/> reference-style link.</p>
     </body>


### PR DESCRIPTION
According to the spec

> (no value)
>    The processing default is used. The processing default for the `@format` attribute is determined  by inspecting the value of the `@href` attribute. If the `@href` attribute specifies a file extension, the processing default for the `@format` attribute is that extension, after conversion to lower-case and with no leading period. The only exception to this is if the extension is "xml", in which case the default format is "dita". 

if we do not specify the `format` attribute for a .md file the format will be `md`. 

Specifying `format="md"` breaks the transformation, probably because only `markdown` is supported as a format value. 
Actually, if the format is not specified, DITA-OT processes the document fine, so not as if format will be `md`, as the spec says.