### PR TITLE
Use status="deleted" instead of importance="deleted" for strikethrough text

### DIFF
--- a/src/main/java/com/elovirta/dita/markdown/ToDitaSerializer.java
+++ b/src/main/java/com/elovirta/dita/markdown/ToDitaSerializer.java
@@ -45,7 +45,7 @@ public class ToDitaSerializer implements Visitor {
     private static final Attributes CODEPH_ATTS = buildAtts(PR_D_CODEPH);
     private static final Attributes CODEBLOCK_ATTS = buildAtts(PR_D_CODEBLOCK);
     private static final Attributes DT_ATTS = buildAtts(TOPIC_DT);
-    private static final Attributes DEL_ATTS = new AttributesBuilder().add(ATTRIBUTE_NAME_CLASS, TOPIC_PH.toString()).add("importance", "deleted").build();
+    private static final Attributes DEL_ATTS = new AttributesBuilder().add(ATTRIBUTE_NAME_CLASS, TOPIC_PH.toString()).add("status", "deleted").build();
     private static final Attributes TITLE_ATTS = buildAtts(TOPIC_TITLE);
     private static final Attributes BLOCKQUOTE_ATTS = buildAtts(TOPIC_LQ);
     private static final Attributes UL_ATTS = buildAtts(TOPIC_UL);

--- a/src/test/resources/test.dita
+++ b/src/test/resources/test.dita
@@ -3,7 +3,7 @@
        id="test">
   <title class="- topic/title ">Test</title>
   <body class="- topic/body ">
-    <p class="- topic/p ">Paragraph <i class="+ topic/ph hi-d/i ">test</i> and <b class="+ topic/ph hi-d/b ">list</b>:</p>
+    <p class="- topic/p ">Paragraph <ph status="deleted" class="- topic/ph ">Text</ph> <i class="+ topic/ph hi-d/i ">test</i> and <b class="+ topic/ph hi-d/b ">list</b>:</p>
     <ul class="- topic/ul ">
       <li class="- topic/li ">hyphen</li>
       <li class="- topic/li ">list</li>

--- a/src/test/resources/test.md
+++ b/src/test/resources/test.md
@@ -1,6 +1,6 @@
 # Test
 
-Paragraph *test* and **list**:
+Paragraph ~~Text~~ *test* and **list**:
 
 -   hyphen
 -   list


### PR DESCRIPTION
```md
~~removed~~
```
resulted in
```xml
<ph importance="deleted">removed</ph>
```
The importance attribute is defined in the DTD to take values from an enumeration
```
importance
  (default |
  deprecated |
  high |
  low |
  normal |
  obsolete |
  optional |
  recommended |
  required |
  urgent |
  -dita-use-conref-target)
  #IMPLIED
```
and `deleted` is not one of those values, so the generated DITA is invalid.

We can use `status="deleted"` instead.
