### PR TITLE
Bring output-message usage up to date

### DIFF
--- a/src/main/resources/abbrev-d.xsl
+++ b/src/main/resources/abbrev-d.xsl
@@ -27,8 +27,7 @@
   <xsl:template match="*" mode="ditamsg:no-glossentry-for-abbreviated-form">
     <xsl:param name="keys"/>
     <xsl:call-template name="output-message">
-      <xsl:with-param name="msgnum">060</xsl:with-param>
-      <xsl:with-param name="msgsev">W</xsl:with-param>
+      <xsl:with-param name="id">DOTX060W</xsl:with-param>
       <xsl:with-param name="msgparams">%1=<xsl:value-of select="$keys"/></xsl:with-param>
     </xsl:call-template>
   </xsl:template>

--- a/src/main/resources/dita2markdownImpl.xsl
+++ b/src/main/resources/dita2markdownImpl.xsl
@@ -2425,8 +2425,7 @@
 <xsl:template name="sect-heading">
   <xsl:param name="defaulttitle"/> <!-- get param by reference -->
   <xsl:call-template name="output-message">
-    <xsl:with-param name="msgnum">066</xsl:with-param>
-    <xsl:with-param name="msgsev">W</xsl:with-param>
+    <xsl:with-param name="id">DOTX066W</xsl:with-param>
     <xsl:with-param name="msgparams">%1=sect-heading</xsl:with-param>
   </xsl:call-template>
   <xsl:apply-templates select="." mode="dita2html:section-heading">
@@ -2968,41 +2967,35 @@
   <xsl:template match="*" mode="ditamsg:no-glossentry-for-key">
     <xsl:param name="matching-keys"/>
     <xsl:call-template name="output-message">
-      <xsl:with-param name="msgnum">058</xsl:with-param>
-      <xsl:with-param name="msgsev">W</xsl:with-param>
+      <xsl:with-param name="id">DOTX058W</xsl:with-param>
       <xsl:with-param name="msgparams">%1=<xsl:value-of select="$matching-keys"/>;%2=<xsl:value-of select="name()"/></xsl:with-param>
     </xsl:call-template>
   </xsl:template>
   <xsl:template match="*" mode="ditamsg:no-title-for-topic">
     <xsl:call-template name="output-message">
-      <xsl:with-param name="msgnum">037</xsl:with-param>
-      <xsl:with-param name="msgsev">W</xsl:with-param>
-    </xsl:call-template>
+      <xsl:with-param name="id">DOTX037W</xsl:with-param>
+      </xsl:call-template>
   </xsl:template>
   <xsl:template match="*" mode="ditamsg:longdescref-on-object">
     <xsl:call-template name="output-message">
-     <xsl:with-param name="msgnum">038</xsl:with-param>
-     <xsl:with-param name="msgsev">I</xsl:with-param>
+     <xsl:with-param name="id">DOTX038I</xsl:with-param>
      <xsl:with-param name="msgparams">%1=<xsl:value-of select="name(.)"/></xsl:with-param>
     </xsl:call-template>
   </xsl:template>
   <xsl:template match="*" mode="ditamsg:required-cleanup-in-content">
     <xsl:call-template name="output-message">
-     <xsl:with-param name="msgnum">039</xsl:with-param>
-     <xsl:with-param name="msgsev">W</xsl:with-param>
-    </xsl:call-template>
+     <xsl:with-param name="id">DOTX039W</xsl:with-param>
+     </xsl:call-template>
   </xsl:template>
   <xsl:template match="*" mode="ditamsg:draft-comment-in-content">
     <xsl:call-template name="output-message">
-     <xsl:with-param name="msgnum">040</xsl:with-param>
-     <xsl:with-param name="msgsev">I</xsl:with-param>
-    </xsl:call-template>
+     <xsl:with-param name="id">DOTX040I</xsl:with-param>
+     </xsl:call-template>
   </xsl:template>
   <xsl:template match="*" mode="ditamsg:section-with-multiple-titles">
     <xsl:call-template name="output-message">
-      <xsl:with-param name="msgnum">041</xsl:with-param>
-      <xsl:with-param name="msgsev">W</xsl:with-param>
-    </xsl:call-template>
+      <xsl:with-param name="id">DOTX041W</xsl:with-param>
+      </xsl:call-template>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/src/main/resources/map2markdownImpl.xsl
+++ b/src/main/resources/map2markdownImpl.xsl
@@ -151,8 +151,7 @@
 
   <xsl:template match="*" mode="ditamsg:missing-target-file-no-navtitle">
     <xsl:call-template name="output-message">
-      <xsl:with-param name="msgnum">008</xsl:with-param>
-      <xsl:with-param name="msgsev">W</xsl:with-param>
+      <xsl:with-param name="id">DOTX008W</xsl:with-param>
       <xsl:with-param name="msgparams">%1=<xsl:value-of select="@href"/></xsl:with-param>
     </xsl:call-template>
   </xsl:template>
@@ -161,8 +160,7 @@
     <xsl:param name="target"/>
     <xsl:param name="fallback"/>
     <xsl:call-template name="output-message">
-      <xsl:with-param name="msgnum">009</xsl:with-param>
-      <xsl:with-param name="msgsev">W</xsl:with-param>
+      <xsl:with-param name="id">DOTX009W</xsl:with-param>
       <xsl:with-param name="msgparams">%1=<xsl:value-of select="$target"/>;%2=<xsl:value-of select="$fallback"/></xsl:with-param>
     </xsl:call-template>
   </xsl:template>

--- a/src/main/resources/rel-links.xsl
+++ b/src/main/resources/rel-links.xsl
@@ -776,8 +776,7 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
       </xsl:call-template>
     </xsl:param>
     <xsl:call-template name="output-message">
-      <xsl:with-param name="msgnum">043</xsl:with-param>
-      <xsl:with-param name="msgsev">I</xsl:with-param>
+      <xsl:with-param name="id">DOTX043I</xsl:with-param>
       <xsl:with-param name="msgparams">%1=<xsl:value-of select="$href"/>;%2=<xsl:value-of select="$outfile"/></xsl:with-param>
     </xsl:call-template>
   </xsl:template>

--- a/src/main/resources/ut-d.xsl
+++ b/src/main/resources/ut-d.xsl
@@ -132,29 +132,25 @@
 
   <xsl:template match="*" mode="ditamsg:area-element-without-href-target">
     <xsl:call-template name="output-message">
-      <xsl:with-param name="msgnum">044</xsl:with-param>
-      <xsl:with-param name="msgsev">E</xsl:with-param>
-    </xsl:call-template>
+      <xsl:with-param name="id">DOTX044E</xsl:with-param>
+      </xsl:call-template>
   </xsl:template>
   <xsl:template match="*" mode="ditamsg:area-element-without-linktext">
     <xsl:call-template name="output-message">
-      <xsl:with-param name="msgnum">045</xsl:with-param>
-      <xsl:with-param name="msgsev">W</xsl:with-param>
-    </xsl:call-template>
+      <xsl:with-param name="id">DOTX045W</xsl:with-param>
+      </xsl:call-template>
   </xsl:template>
   <xsl:template match="*" mode="ditamsg:area-element-unknown-shape">
     <xsl:param name="shapeval" select="*[contains(@class,' ut-d/shape ')]/text()"/>
     <xsl:call-template name="output-message">
-      <xsl:with-param name="msgnum">046</xsl:with-param>
-      <xsl:with-param name="msgsev">W</xsl:with-param>
+      <xsl:with-param name="id">DOTX046W</xsl:with-param>
       <xsl:with-param name="msgparams">%1=<xsl:value-of select="$shapeval"/></xsl:with-param>
     </xsl:call-template>
   </xsl:template>
   <xsl:template match="*" mode="ditamsg:area-element-missing-coords">
     <xsl:call-template name="output-message">
-      <xsl:with-param name="msgnum">047</xsl:with-param>
-      <xsl:with-param name="msgsev">W</xsl:with-param>
-    </xsl:call-template>
+      <xsl:with-param name="id">DOTX047W</xsl:with-param>
+      </xsl:call-template>
   </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
The `output-message` templates used in current markdown code are out of date, and will generate a "deprecated parameter" message. This pull request just brings them up to date.

Signed-off-by: Robert D Anderson <robander@us.ibm.com>